### PR TITLE
Update automount_config.go

### DIFF
--- a/internal/cli/automount_config.go
+++ b/internal/cli/automount_config.go
@@ -30,7 +30,7 @@ func RegisterAutomountFlags(config *AutomountConfig) {
 
 	kingpin.Flag(MountRootFlag,
 		"Directory in which to mount devices.").
-		Short('r').
+		Short('p').
 		PlaceHolder("/mnt").
 		ExistingDirVar(&config.MountRoot)
 	kingpin.Flag("adbfs",


### PR DESCRIPTION
change short form of --root flag from -r to -p because adbfs binary also has a -r flag which causes conflicts resulting in automount not working.